### PR TITLE
MongoDB: Filter Enforcer

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/FilterEnforcer.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/FilterEnforcer.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import io.trino.spi.TrinoException;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.spi.StandardErrorCode.QUERY_REJECTED;
+
+public class FilterEnforcer
+{
+    private Map<String, List<String>> requiredFilters;
+
+    public FilterEnforcer(String requiredFiltersConfig)
+    {
+        this.requiredFilters = new HashMap<>();
+        if (requiredFiltersConfig == null) {
+            return;
+        }
+        for (String entry : requiredFiltersConfig.split(",")) {
+            String[] tokens = entry.split(":");
+            List<String> list = this.requiredFilters.computeIfAbsent(tokens[0], k -> new ArrayList<>());
+            list.add(tokens[1]);
+        }
+    }
+
+    public void checkAndRaiseIfInvalid(String collectionName, Document filter)
+            throws TrinoException
+    {
+        List<String> requiredFilters = this.requiredFilters.get(collectionName);
+        if (requiredFilters == null) {
+            return;
+        }
+        for (String requiredFilter : requiredFilters) {
+            if (requiredFilter != null && !contains(filter, requiredFilter)) {
+                throw new TrinoException(QUERY_REJECTED, "Collection '%s' requires a filter on '%s'!".formatted(collectionName, requiredFilter));
+            }
+        }
+    }
+
+    private static boolean contains(Object object, String requiredFilter)
+    {
+        if (object instanceof Document documentEntry) {
+            if (documentEntry.containsKey(requiredFilter)) {
+                return true;
+            }
+            else {
+                for (Object item : documentEntry.values()) {
+                    if (contains(item, requiredFilter)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        else if (object instanceof Iterable iterableEntry) {
+            for (Object item : iterableEntry) {
+                if (contains(item, requiredFilter)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -52,6 +52,8 @@ public class MongoClientConfig
     private boolean allowLocalScheduling;
     private Duration dynamicFilteringWaitTimeout = new Duration(5, SECONDS);
 
+    private String requiredFilters;
+
     @NotNull
     public String getSchemaCollection()
     {
@@ -283,6 +285,19 @@ public class MongoClientConfig
     public MongoClientConfig setDynamicFilteringWaitTimeout(Duration dynamicFilteringWaitTimeout)
     {
         this.dynamicFilteringWaitTimeout = dynamicFilteringWaitTimeout;
+        return this;
+    }
+
+    public @Pattern(message = "Invalid 'required-filters'. Expected a comma-separated list of <key>:<value> pairs.", regexp = "^([^:,]+:[^:,]+,?)*$") String getRequiredFilters()
+    {
+        return requiredFilters;
+    }
+
+    @Config("mongodb.required-filters")
+    @ConfigDescription("Comma-separated list of <collection>:<key> pairs indicating a <collection> requires a filter on key <key>.")
+    public MongoClientConfig setRequiredFilters(String requiredFilters)
+    {
+        this.requiredFilters = requiredFilters;
         return this;
     }
 }


### PR DESCRIPTION
Adds a configuration option to enforce a filter (or a set of them) on a particular collection (or more).

Simple example: the following configuration
```
mongodb.required-filters=books:author_id
```
will reject queries without a WHERE clause on `author_id` when selecting from `books`, e.g.

```
trino> select * from "bookscatalog".booksdb.books;

Query 20240520_095959_00000_fk3a5, FAILED, 1 node
Splits: 1 total, 0 done (0.00%)
0.48 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20240520_095959_00000_fk3a5 failed: Collection 'books' requires a filter on 'author_id'!
```

A more complex with multiple fields required on the same collection, and a single field on a different collection:
```
mongodb.required-filters=books:author_id,books:publisher_id,authors:id
```